### PR TITLE
Update method to use WeakMap and use immutable@4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,7 @@ class ExampleRecord extends Record({}) {
     }
 }
 
-// Memoize methods with no arguments
-memoize(ExampleRecord.prototype, ['noArguments'], { takesArguments: false });
-
-// Memoize methods that have arguments
-memoize(ExampleObject.prototype, ['withArguments'], { takesArguments: true });
+memoize(ExampleRecord.prototype, ['noArguments', 'withArguments']);
 
 // Use ExampleRecord as usual
 ```
@@ -58,10 +54,7 @@ ExampleObject.prototype = {
 };
 
 // Memoize methods with no arguments
-memoize(ExampleObject.prototype, ['noArguments'], { takesArguments: false });
-
-// Memoize methods that have arguments
-memoize(ExampleObject.prototype, ['withArguments'], { takesArguments: true });
+memoize(ExampleObject.prototype, ['noArguments', 'withArguments']);
 
 // Use ExampleObject as usual
 ```
@@ -78,8 +71,6 @@ Arguments:
   The object prototype that should have its properties memoized.
 - `properties: string[]`
   The list of properties names that should be memoized
-- `options.takesArguments?: boolean`
-  True if the methods in `properties` take arguments. This result in slower memoization for them.
 
 Returns: `void`
 
@@ -88,3 +79,7 @@ Returns: `void`
 
 Implementation is taken from Slate.
 https://github.com/ianstormtaylor/slate/blob/master/src/utils/memoize.js
+
+Thank you to:
+
+- [@zhujinxuan](https://github.com/zhujinxuan)

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -10,8 +10,7 @@ function testOn(t, object) {
     const { methodNoArgs, methodArgs } = object.prototype;
 
     // Memoize
-    memoize(object.prototype, ['methodArgs'], { takesArguments: true });
-    memoize(object.prototype, ['methodNoArgs'], { takesArguments: false });
+    memoize(object.prototype, ['methodArgs', 'methodNoArgs']);
 
     // Test
     const instance = new object();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,11 @@
 /* @flow */
 
 /*
+ * GLOBAL: True if memoization should is enabled.	 * GLOBAL: True if memoization should is enabled.
+ */
+let ENABLED = true;
+
+/*
  * The node of a cache tree for a WeakMap to store cache visited by objects
  */
 const STORE_KEY = Symbol('STORE_KEY');
@@ -45,6 +50,11 @@ function memoize(
         }
 
         object[property] = function(...args) {
+            // If memoization is disabled, call into the original method.
+            if (!ENABLED) {
+                return original.apply(this, args);
+            }
+
             if (!memoizeStore.has(this)) {
                 memoizeStore.set(this, {
                     noArgs: {},
@@ -167,5 +177,13 @@ function resetMemoization() {
     memoizeStore = new WeakMap();
 }
 
+/*
+ * In DEV mode, enable or disable the use of memoize values, globally.
+ */
+
+function useMemoization(enabled: boolean) {
+    ENABLED = enabled;
+}
+
 export default memoize;
-export { resetMemoization };
+export { resetMemoization, useMemoization };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,40 +1,42 @@
-// @flow
+/* @flow */
 
-import Map from 'es6-map';
+/*
+ * The node of a cache tree for a WeakMap to store cache visited by objects
+ */
+const STORE_KEY = Symbol('STORE_KEY');
 
-/**
+/*
  * The leaf node of a cache tree. Used to support variable argument length. A
  * unique object, so that native Maps will key it by reference.
  */
-const LEAF = {};
+const LEAF = Symbol('LEAF');
 
-/**
+/*
  * A value to represent a memoized undefined value. Allows efficient value
  * retrieval using Map.get only.
  */
-const UNDEFINED = {};
+const UNDEFINED = Symbol('undefined');
+const NULL = Symbol('null');
 
-/**
+/*
  * Default value for unset keys in native Maps
  */
 const UNSET = undefined;
 
-/**
+/*
+ * Global Store for all cached values
+ */
+let memoizeStore = new WeakMap();
+
+/*
  * Memoize all of the `properties` on an `object`.
  */
 function memoize(
     // The object prototype that should have its properties memoized.
     object: Object,
     // The list of properties names that should be memoized
-    properties: string[],
-    options: {
-        // True if the methods in `properties` take arguments. This result in
-        // slower memoization.
-        takesArguments?: boolean
-    } = {}
+    properties: string[]
 ) {
-    const { takesArguments = true } = options;
-
     for (const property of properties) {
         const original = object[property];
 
@@ -43,18 +45,24 @@ function memoize(
         }
 
         object[property] = function(...args) {
-            if (!this.__cache) {
-                this.__cache = new Map();
+            if (!memoizeStore.has(this)) {
+                memoizeStore.set(this, {
+                    noArgs: {},
+                    hasArgs: {}
+                });
             }
 
-            let cachedValue;
+            const { noArgs, hasArgs } = memoizeStore.get(this);
+            const takesArguments = args.length !== 0;
 
+            let cachedValue;
             let keys = [];
+
             if (takesArguments) {
                 keys = [property, ...args];
-                cachedValue = getIn(this.__cache, keys);
+                cachedValue = getIn(hasArgs, keys);
             } else {
-                cachedValue = this.__cache.get(property);
+                cachedValue = noArgs[property];
             }
 
             // If we've got a result already, return it.
@@ -67,9 +75,9 @@ function memoize(
             const v = value === undefined ? UNDEFINED : value;
 
             if (takesArguments) {
-                this.__cache = setIn(this.__cache, keys, v);
+                setIn(hasArgs, keys, v);
             } else {
-                this.__cache.set(property, v);
+                noArgs[property] = v;
             }
 
             return value;
@@ -77,50 +85,87 @@ function memoize(
     }
 }
 
-/**
+/*
  * Get a value at a key path in a tree of Map.
  *
  * If not set, returns UNSET.
  * If the set value is undefined, returns UNDEFINED.
  */
 function getIn(
-    map: Map,
+    map: {},
     keys: string[]
-): (any | typeof UNSET | typeof UNDEFINED) {
-    for (const key of keys) {
-        map = map.get(key);
+): (any | typeof UNSET | typeof UNDEFINED | typeof NULL) {
+    for (let key of keys) {
+        if (key === undefined) {
+            key = UNDEFINED;
+        } else if (key === null) {
+            key = NULL;
+        }
+
+        if (typeof key === 'object') {
+            map = map[STORE_KEY] && map[STORE_KEY].get(key);
+        } else {
+            map = map[key];
+        }
+
         if (map === UNSET) return UNSET;
     }
 
-    return map.get(LEAF);
+    return map[LEAF];
 }
 
-/**
+/*
  * Set a value at a key path in a tree of Map, creating Maps on the go.
  */
 function setIn(
-    map: Map,
+    map: {},
     keys: string[],
     value: any
-): Map {
-    let parent = map;
-    let child;
+): {} {
+    let child = map;
 
-    for (const key of keys) {
-        child = parent.get(key);
-
-        // If the path was not created yet...
-        if (child === UNSET) {
-            child = new Map();
-            parent.set(key, child);
+    for (let key of keys) {
+        if (key === undefined) {
+            key = UNDEFINED;
+        } else if (key === null) {
+            key = NULL;
         }
 
-        parent = child;
+        if (typeof key !== 'object') {
+            if (!child[key]) {
+                child[key] = {};
+            }
+
+            child = child[key];
+            continue;
+        }
+
+        if (!child[STORE_KEY]) {
+            child[STORE_KEY] = new WeakMap();
+        }
+
+        if (!child[STORE_KEY].has(key)) {
+            const newChild = {};
+            child[STORE_KEY].set(key, newChild);
+            child = newChild;
+            continue;
+        }
+
+        child = child[STORE_KEY].get(key);
     }
 
-    // The whole path has been created, so set the value to the bottom most map.
-    child.set(LEAF, value);
+  // The whole path has been created, so set the value to the bottom most map.
+    child[LEAF] = value;
     return map;
 }
 
+/*
+ * Clears the previously memoized values, globally.
+ */
+
+function resetMemoization() {
+    memoizeStore = new WeakMap();
+}
+
 export default memoize;
+export { resetMemoization };

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "babel ./lib --out-dir ./dist",
-    "prepublish": "yarn run build",
+    "prepare": "babel ./lib --out-dir ./dist",
     "lint": "eslint ./",
     "test": "ava"
   },
@@ -38,14 +37,12 @@
     "eslint-config-gitbook": "^1.5.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "flow-bin": "^0.52.0",
-    "immutable": "^3.8.1",
+    "immutable": "^4.0.0-rc.12",
     "sinon": "^3.2.0"
   },
   "ava": {
     "require": "babel-register",
     "babel": "inherit"
   },
-  "dependencies": {
-    "es6-map": "^0.1.5"
-  }
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,7 +1505,7 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@^0.1.3, es6-map@^0.1.5:
+es6-map@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
@@ -2073,9 +2073,9 @@ ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
-immutable@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
 
 import-lazy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR updates the `immutable` dependency to `4.0.0` (so that tests ensure it still works).

It also updates the method using @zhujinxuan in https://github.com/ianstormtaylor/slate/pull/2471 (added to credits)

I'll make a PR in https://github.com/GitbookIO/slate to use this repository instead of an inline dependency.